### PR TITLE
raise runtime error if segmentation in obj not found

### DIFF
--- a/segment.py
+++ b/segment.py
@@ -116,6 +116,9 @@ meta = {}
 meta['view_segment'] = OBJ_INPUT != ''
 meta['obj'] = []
 
+if len(SEGMENT_LIST) == 0:
+    raise Exception('No .obj files found in .volpkg folder')
+
 for SEGMENT_ID in SEGMENT_LIST:
     filename = f'{OBJ_OUTPUT}/{SEGMENT_ID}.obj'
 

--- a/segment.py
+++ b/segment.py
@@ -110,14 +110,14 @@ if (OBJ_INPUT != ''):
         if os.path.isfile(obj_file_path):
             shutil.copy(obj_file_path , OBJ_OUTPUT)
             SEGMENT_LIST.append(folder_name)
+        else:
+            raise RuntimeError(f'No .obj file found in {subfolder}. Please check your .volpkg folder.')
 
 # parse .obj files and get relevant info and copy to client
 meta = {}
 meta['view_segment'] = OBJ_INPUT != ''
 meta['obj'] = []
 
-if len(SEGMENT_LIST) == 0:
-    raise Exception('No .obj files found in .volpkg folder')
 
 for SEGMENT_ID in SEGMENT_LIST:
     filename = f'{OBJ_OUTPUT}/{SEGMENT_ID}.obj'


### PR DESCRIPTION
Raise Runtime error if the segmentation file type is not supported.

#1 